### PR TITLE
Handle empty SNPs

### DIFF
--- a/src/snps/__init__.py
+++ b/src/snps/__init__.py
@@ -48,7 +48,7 @@ from pandas.api.types import CategoricalDtype
 from snps.ensembl import EnsemblRestClient
 from snps.resources import Resources
 from snps.io import Reader, Writer
-from snps.utils import save_df_as_csv, Parallelizer, clean_str
+from snps.utils import save_df_as_csv, Parallelizer, clean_str, get_empty_snps_dataframe
 
 # set version string with Versioneer
 from snps._version import get_versions
@@ -102,7 +102,7 @@ class SNPs:
         """
         self._file = file
         self._only_detect_source = only_detect_source
-        self._snps = pd.DataFrame()
+        self._snps = get_empty_snps_dataframe()
         self._duplicate_snps = pd.DataFrame()
         self._discrepant_XY_snps = pd.DataFrame()
         self._source = ""

--- a/src/snps/__init__.py
+++ b/src/snps/__init__.py
@@ -140,6 +140,8 @@ class SNPs:
 
                 if assign_par_snps:
                     self._assign_par_snps()
+            else:
+                logger.warning("no SNPs loaded...")
 
     def __repr__(self):
         return "SNPs({!r})".format(self._file[0:50])

--- a/src/snps/io.py
+++ b/src/snps/io.py
@@ -47,7 +47,7 @@ import numpy as np
 import pandas as pd
 
 import snps
-from snps.utils import save_df_as_csv, clean_str
+from snps.utils import save_df_as_csv, clean_str, get_empty_snps_dataframe
 
 import logging
 
@@ -94,7 +94,7 @@ class Reader:
         """
         file = self._file
         compression = "infer"
-        d = {"snps": pd.DataFrame(), "source": "", "phased": False}
+        d = {"snps": get_empty_snps_dataframe(), "source": "", "phased": False}
 
         # peek into files to determine the data format
         if isinstance(file, str) and os.path.exists(file):
@@ -297,7 +297,7 @@ class Reader:
         phased = False
 
         if self._only_detect_source:
-            df = pd.DataFrame()
+            df = get_empty_snps_dataframe()
         else:
             df, *extra = parser()
 

--- a/src/snps/io.py
+++ b/src/snps/io.py
@@ -1090,7 +1090,7 @@ class Writer:
         results = map(self._create_vcf_representation, tasks)
 
         contigs = []
-        vcf = []
+        vcf = [pd.DataFrame()]
         for result in list(results):
             contigs.append(result["contig"])
             vcf.append(result["vcf"])

--- a/src/snps/io.py
+++ b/src/snps/io.py
@@ -720,18 +720,12 @@ class Reader:
                 )
 
             try:
-                return (
-                    parse_csv(","),
-                    phased,
-                )
+                return (parse_csv(","), phased)
             except pd.errors.ParserError:
                 if isinstance(file, io.BufferedIOBase):
                     file.seek(0)
 
-                return (
-                    parse_csv("\t"),
-                    phased,
-                )
+                return (parse_csv("\t"), phased)
 
         return self.read_helper(source, parser)
 

--- a/src/snps/utils.py
+++ b/src/snps/utils.py
@@ -211,3 +211,15 @@ def clean_str(s):
     # http://stackoverflow.com/a/3305731
     # https://stackoverflow.com/a/52335971
     return re.sub(r"\W|^(?=\d)", "_", s)
+
+
+def get_empty_snps_dataframe():
+    """ Get empty dataframe normalized for usage with `snps`.
+
+    Returns
+    -------
+    pd.DataFrame
+    """
+    df = pd.DataFrame(columns=["rsid", "chrom", "pos", "genotype"])
+    df.set_index("rsid", inplace=True)
+    return df

--- a/tests/test_snps.py
+++ b/tests/test_snps.py
@@ -210,3 +210,17 @@ class TestSnps(BaseSNPsTestCase):
             genotype=["AA", "CC", "GG"],
         )
         pd.testing.assert_frame_equal(snps.snps, result)
+
+    def test_empty_dataframe(self):
+        s = SNPs()
+        assert s.snp_count == 0
+        assert list(s.snps.columns.values) == ["chrom", "pos", "genotype"]
+        assert s.snps.index.name == "rsid"
+
+    def test_empty_dataframe_file(self):
+        with atomic_write("tests/input/empty.txt", mode="w", overwrite=True):
+            pass
+        s = SNPs("tests/input/empty.txt")
+        assert s.snp_count == 0
+        assert list(s.snps.columns.values) == ["chrom", "pos", "genotype"]
+        assert s.snps.index.name == "rsid"

--- a/tests/test_snps_collection.py
+++ b/tests/test_snps_collection.py
@@ -745,6 +745,10 @@ class TestSNPsCollection(BaseSNPsTestCase):
         s = SNPs()
         assert not s.save_snps()
 
+    def test_save_snps_no_snps_vcf(self):
+        s = SNPs()
+        assert not s.save_snps(vcf=True)
+
     def test_save_discrepant_positions(self):
         sc = SNPsCollection()
         sc.load_snps(["tests/input/NCBI36.csv", "tests/input/GRCh37.csv"])


### PR DESCRIPTION
This PR initializes a `SNPs` object with an empty, normalized dataframe (fixing the error discovered by @PhilPalmer in #57).

Additionally, as suggested by @willgdjones in #57, a warning message is generated if no SNPs are loaded when instantiating a `SNPs` object.