### PR TITLE
Assign PAR SNPs before deduplicating XY chroms

### DIFF
--- a/src/snps/snps.py
+++ b/src/snps/snps.py
@@ -137,13 +137,13 @@ class SNPs:
                     else:
                         self._build_detected = True
 
-                if deduplicate_XY_chrom:
-                    if self.determine_sex() == "Male":
-                        self._deduplicate_XY_chrom()
-
                 if assign_par_snps:
                     self._assign_par_snps()
                     self.sort_snps()
+
+                if deduplicate_XY_chrom:
+                    if self.determine_sex() == "Male":
+                        self._deduplicate_XY_chrom()
             else:
                 logger.warning("no SNPs loaded...")
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -308,11 +308,11 @@ class BaseSNPsTestCase(TestCase):
         ]
 
         if self.downloads_enabled:
-            return SNPs(path, assign_par_snps=True)
+            return SNPs(path, assign_par_snps=True, deduplicate_XY_chrom=False)
         else:
             mock = Mock(side_effect=effects)
             with patch("snps.ensembl.EnsemblRestClient.perform_rest_action", mock):
-                return SNPs(path, assign_par_snps=True)
+                return SNPs(path, assign_par_snps=True, deduplicate_XY_chrom=False)
 
     def _get_test_assembly_mapping_data(self, source, target, strands, mappings):
         return {


### PR DESCRIPTION
PAR SNPs should be assigned to X or Y before deduplicating alleles.