### PR TITLE
Use tab as default separator

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -24,19 +24,21 @@ Other Contributors
 
 Listed in alphabetical order.
 
-================ ===============
+================ =================
 Name             GitHub
-================ ===============
+================ =================
 Alan Moffet      `@amoffet`_
 Anatoli Babenia  `@abitrolly`_
 Castedo Ellerman `@castedo`_
+Gerard Manning   `@GerardManning`_
 Kevin Arvai      `@arvkevi`_
 Phil Palmer      `@PhilPalmer`_
 Yoan Bouzin
-================ ===============
+================ =================
 
 .. _@amoffet: https://github.com/amoffet
 .. _@abitrolly: https://github.com/abitrolly
 .. _@castedo: https://github.com/castedo
+.. _@GerardManning: https://github.com/GerardManning
 .. _@arvkevi: https://github.com/arvkevi
 .. _@PhilPalmer: https://github.com/PhilPalmer

--- a/README.rst
+++ b/README.rst
@@ -168,7 +168,7 @@ identifying discrepancies along the way. Let's save the merged dataset consistin
 SNPs to a CSV file:
 
 >>> saved_snps = sc.save_snps()
-Saving output/User662_GRCh37.csv
+Saving output/User662_GRCh37.txt
 
 Moreover, let's get the reference sequences for this assembly and save the SNPs as a VCF file:
 

--- a/docs/output_files.rst
+++ b/docs/output_files.rst
@@ -1,21 +1,21 @@
 Output Files
 ============
-The various output files produced by ``snps`` are detailed below. Output files are saved in
-the output directory, which is defined at the instantiation of the :class:`~snps.SNPs`
-object. Generation of output files can usually be enabled or disabled via a ``save_output``
-argument to the associated method.
+The various output files produced by ``snps`` are detailed below. Output files are saved in the
+output directory, which is defined at the instantiation of a :class:`~snps.snps.SNPs` or
+:class:`~snps.snps_collection.SNPsCollection` object.
 
 Load SNPs
 ---------
-Multiple raw data files can be loaded when an :class:`~snps.SNPsCollection` is instantiated.
+Multiple raw data files can be loaded when a :class:`~snps.snps_collection.SNPsCollection` is
+instantiated.
 
 When loading multiple raw data files, if there are any discrepancies between the existing data
 and the new data, those are noted. Specifically, discrepancies in SNP positions and genotypes
-are output as CSV files. Output of these files is enabled via the ``save_output=True`` argument to
-:meth:`~snps.SNPsCollection.load_snps`.
+are output as CSV files. Output of these files is enabled via the ``save_output=True`` argument
+to :meth:`~snps.snps_collection.SNPsCollection.load_snps`.
 
 discrepant_positions_<num>.csv
-`````````````````````````````````````
+``````````````````````````````
 Where ``num`` indicates the file count for discrepant positions files.
 
 ==============  ===========
@@ -34,7 +34,7 @@ A large number of discrepant positions could indicate that the files contain SNP
 builds / assemblies.
 
 discrepant_genotypes_<num>.csv
-`````````````````````````````````````
+``````````````````````````````
 Where ``num`` indicates the file count for discrepant genotypes files.
 
 ===============  ===========
@@ -57,8 +57,9 @@ Discrepant SNPs
 Summaries can be saved of the discrepant SNPs found while loading files.
 
 discrepant_positions.csv
-```````````````````````````````
-SNPs with discrepant positions can be saved with :meth:`~snps.SNPsCollection.save_discrepant_positions`.
+````````````````````````
+SNPs with discrepant positions can be saved with
+:meth:`~snps.snps_collection.SNPsCollection.save_discrepant_positions`.
 
 ==============  ===========
 Column          Description
@@ -73,8 +74,9 @@ genotype_added  Genotype of added SNP
 ==============  ===========
 
 discrepant_genotypes.csv
-```````````````````````````````
-SNPs with discrepant genotypes can be saved with :meth:`~snps.SNPsCollection.save_discrepant_genotypes`.
+````````````````````````
+SNPs with discrepant genotypes can be saved with
+:meth:`~snps.snps_collection.SNPsCollection.save_discrepant_genotypes`.
 
 ===============  ===========
 Column           Description
@@ -89,8 +91,9 @@ genotype_added   Genotype of added SNP (discrepant with genotype)
 ===============  ===========
 
 discrepant_snps.csv
-``````````````````````````
-SNPs with discrepant positions and / or genotypes can be saved with :meth:`~snps.SNPsCollection.save_discrepant_snps`.
+```````````````````
+SNPs with discrepant positions and / or genotypes can be saved with
+:meth:`~snps.snps_collection.SNPsCollection.save_discrepant_snps`.
 
 ===============  ===========
 Column           Description
@@ -106,14 +109,12 @@ genotype_added   Genotype of added SNP (possibly discrepant with genotype)
 
 Save SNPs
 ---------
-The SNPs for a :class:`~snps.SNPs` or :class:`~snps.SNPsCollection` object can be saved with
-:meth:`~snps.SNPs.save_snps` or :meth:`~snps.SNPsCollection.save_snps`, respectively. One CSV or
-VCF file (``vcf=True``) is output when SNPs are saved.
+SNPs can be saved with :meth:`SNPs.save_snps <snps.snps.SNPs.save_snps>` or
+:meth:`SNPsCollection.save_snps <snps.snps_collection.SNPsCollection.save_snps>`. By default, one
+tab-separated ``.txt`` or ``.vcf`` file (``vcf=True``) is output when SNPs are saved. If comma
+is specified as the separator (``sep=","``), the default extension is ``.csv``.
 
-<source>_<assembly>.csv
-`````````````````````````````
-Where ``source`` is the detected source of SNPs data and ``assembly`` is the assembly of the
-SNPs being saved.
+The content of non-VCF files (after comment lines, which start with ``#``) is as follows:
 
 ==========  ===========
 Column      Description
@@ -123,3 +124,23 @@ chromosome  Chromosome of SNP
 position    Position of SNP
 genotype    Genotype of SNP
 ==========  ===========
+
+When ``filename`` is not specified, default filenames are used as described below.
+
+:meth:`SNPs.save_snps <snps.snps.SNPs.save_snps>`
+`````````````````````````````````````````````````
+
+<source>_<assembly>.txt / <source>_<assembly>.csv
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Where ``source`` is the detected source of SNPs data and ``assembly`` is the assembly of the
+SNPs being saved.
+
+
+:meth:`SNPsCollection.save_snps <snps.snps_collection.SNPsCollection.save_snps>`
+````````````````````````````````````````````````````````````````````````````````
+
+<name>_<assembly>.txt / <name>_<assembly>.csv
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Where ``name`` is the name (if any) for the :class:`~snps.snps_collection.SNPsCollection` and
+``assembly`` is the assembly of the SNPs being saved. If name is not specified, ``<name>_`` is
+not included in the filename.

--- a/src/snps/io/writer.py
+++ b/src/snps/io/writer.py
@@ -113,8 +113,13 @@ class Writer:
         """
         filename = self._filename
         if not filename:
+            ext = ".txt"
+
+            if "sep" in self._kwargs and self._kwargs["sep"] == ",":
+                ext = ".csv"
+
             filename = "{}_{}{}".format(
-                clean_str(self._snps._source), self._snps.assembly, ".csv"
+                clean_str(self._snps._source), self._snps.assembly, ext
             )
 
         comment = (

--- a/src/snps/snps.py
+++ b/src/snps/snps.py
@@ -396,6 +396,9 @@ class SNPs:
         str
             path to file in output directory if SNPs were saved, else empty str
         """
+        if "sep" not in kwargs:
+            kwargs["sep"] = "\t"
+
         return Writer.write_file(
             snps=self, filename=filename, vcf=vcf, atomic=atomic, **kwargs
         )

--- a/src/snps/snps_collection.py
+++ b/src/snps/snps_collection.py
@@ -208,7 +208,9 @@ class SNPsCollection(SNPs):
             if vcf:
                 ext = ".vcf"
             else:
-                ext = ".csv"
+                ext = ".txt"
+                if "sep" in kwargs and kwargs["sep"] == ",":
+                    ext = ".csv"
 
             filename = "{}{}{}".format(prefix, self.assembly, ext)
         return super().save_snps(filename=filename, vcf=vcf, atomic=atomic, **kwargs)

--- a/tests/io/test_writer.py
+++ b/tests/io/test_writer.py
@@ -43,16 +43,23 @@ from tests import BaseSNPsTestCase
 class TestWriter(BaseSNPsTestCase):
     def test_save_snps(self):
         snps = SNPs("tests/input/generic.csv")
-        self.assertEqual(os.path.relpath(snps.save_snps()), "output/generic_GRCh37.csv")
-        self.run_parsing_tests("output/generic_GRCh37.csv", "generic")
+        self.assertEqual(os.path.relpath(snps.save_snps()), "output/generic_GRCh37.txt")
+        self.run_parsing_tests("output/generic_GRCh37.txt", "generic")
 
-    def test_save_snps_tsv(self):
+    def test_save_snps_csv(self):
         snps = SNPs("tests/input/generic.csv")
         self.assertEqual(
-            os.path.relpath(snps.save_snps("generic.tsv", sep="\t")),
-            "output/generic.tsv",
+            os.path.relpath(snps.save_snps(sep=",")), "output/generic_GRCh37.csv",
         )
-        self.run_parsing_tests("output/generic.tsv", "generic")
+        self.run_parsing_tests("output/generic_GRCh37.csv", "generic")
+
+    def test_save_snps_csv_filename(self):
+        snps = SNPs("tests/input/generic.csv")
+        self.assertEqual(
+            os.path.relpath(snps.save_snps("generic.csv", sep=",")),
+            "output/generic.csv",
+        )
+        self.run_parsing_tests("output/generic.csv", "generic")
 
     def test_save_snps_vcf(self):
         s = SNPs("tests/input/testvcf.vcf")
@@ -98,13 +105,13 @@ class TestWriter(BaseSNPsTestCase):
         # read saved VCF
         self.run_parsing_tests_vcf("output/vcf_GRCh37.vcf", phased=True)
 
-    def test_save_snps_csv_phased(self):
+    def test_save_snps_phased(self):
         # read phased data
         s = SNPs("tests/input/testvcf_phased.vcf")
-        # save phased data to CSV
-        self.assertEqual(os.path.relpath(s.save_snps()), "output/vcf_GRCh37.csv")
-        # read saved CSV
-        self.run_parsing_tests_vcf("output/vcf_GRCh37.csv", phased=True)
+        # save phased data to TSV
+        self.assertEqual(os.path.relpath(s.save_snps()), "output/vcf_GRCh37.txt")
+        # read saved TSV
+        self.run_parsing_tests_vcf("output/vcf_GRCh37.txt", phased=True)
 
     def test_save_snps_specify_file(self):
         s = SNPs("tests/input/generic.csv")

--- a/tests/test_snps.py
+++ b/tests/test_snps.py
@@ -300,8 +300,8 @@ class TestSnps(BaseSNPsTestCase):
 
     def test_save_snps_source(self):
         s = SNPs("tests/input/GRCh38.csv")
-        self.assertEqual(os.path.relpath(s.save_snps()), "output/generic_GRCh38.csv")
-        snps = SNPs("output/generic_GRCh38.csv")
+        self.assertEqual(os.path.relpath(s.save_snps()), "output/generic_GRCh38.txt")
+        snps = SNPs("output/generic_GRCh38.txt")
         pd.testing.assert_frame_equal(snps.snps, self.snps_GRCh38(), check_exact=True)
 
     def test_sex_Female_X_chrom(self):

--- a/tests/test_snps_collection.py
+++ b/tests/test_snps_collection.py
@@ -54,17 +54,29 @@ class TestSNPsCollection(BaseSNPsTestCase):
             genotype=["AA", np.nan, "ID", np.nan],
         )
 
-    def test_source_lineage_file(self):
+    def test_source_snps(self):
         sc = SNPsCollection("tests/input/GRCh37.csv")
         self.assertEqual(sc.source, "generic")
         sc.load_snps("tests/input/23andme.txt")
         self.assertEqual(sc.source, "generic, 23andMe")
-        file = sc.save_snps()
-        s = SNPs(file)
+        self.assertEqual(os.path.relpath(sc.save_snps()), "output/GRCh37.txt")
+        s = SNPs("output/GRCh37.txt")
         self.assertEqual(s.source, "generic, 23andMe")
         pd.testing.assert_frame_equal(sc.snps, s.snps, check_exact=True)
 
-    def test_source_lineage_file_gzip(self):
+    def test_source_snps_name_csv(self):
+        sc = SNPsCollection("tests/input/GRCh37.csv", name="test")
+        self.assertEqual(sc.source, "generic")
+        sc.load_snps("tests/input/23andme.txt")
+        self.assertEqual(sc.source, "generic, 23andMe")
+        self.assertEqual(
+            os.path.relpath(sc.save_snps(sep=",")), "output/test_GRCh37.csv"
+        )
+        s = SNPs("output/test_GRCh37.csv")
+        self.assertEqual(s.source, "generic, 23andMe")
+        pd.testing.assert_frame_equal(sc.snps, s.snps, check_exact=True)
+
+    def test_source_snps_gzip(self):
         sc = SNPsCollection("tests/input/GRCh37.csv")
         self.assertEqual(sc.source, "generic")
         sc.load_snps("tests/input/23andme.txt")


### PR DESCRIPTION
Changes behavior of `save_snps` so that the default separator is `\t` (tab) and file extension is `.txt`.

If `,` is used as a separator (via `sep=","` kwarg to `save_snps`), the default file extension is `.csv`.