### PR TITLE
Handle diploid MT genotypes

### DIFF
--- a/src/snps/snps_collection.py
+++ b/src/snps/snps_collection.py
@@ -313,6 +313,10 @@ class SNPsCollection(SNPs):
         if snps._snps.empty:
             return discrepant_positions, discrepant_genotypes
 
+        self._heterozygous_MT_snps = self._heterozygous_MT_snps.append(
+            snps._heterozygous_MT_snps
+        )
+
         build = snps._build
         source = [s.strip() for s in snps._source.split(",")]
 

--- a/src/snps/snps_collection.py
+++ b/src/snps/snps_collection.py
@@ -377,6 +377,10 @@ class SNPsCollection(SNPs):
             # same and not swapped)
             discrepant_genotypes = common_snps.loc[
                 (
+                    common_snps["genotype"].str.len()
+                    != common_snps["genotype_added"].str.len()
+                )
+                | (
                     (common_snps["genotype"].str.len() == 1)
                     & (common_snps["genotype_added"].str.len() == 1)
                     & ~(

--- a/tests/input/ancestry_mt.txt
+++ b/tests/input/ancestry_mt.txt
@@ -1,0 +1,5 @@
+#Ancestry
+rsid	chromosome	position	allele1	allele2
+rs1	26	101	A	A
+rs2	26	102	0	0
+rs3	26	103	G	C


### PR DESCRIPTION
This PR adds the following:
* `deduplicate_MT_chrom` parameter to `SNPs` to deduplicate MT alleles
* `heterozygous_MT_snps` property to identify heterozygous MT SNPs found during deduplication
* `homozygous_snps` helper function