### PR TITLE
Use set for rsids

### DIFF
--- a/src/snps/io/reader.py
+++ b/src/snps/io/reader.py
@@ -101,7 +101,7 @@ class Reader:
         self._file = file
         self._only_detect_source = only_detect_source
         self._resources = resources
-        self._rsids = rsids
+        self._rsids = frozenset(rsids)
 
     def __call__(self):
         """ Read and parse a raw data / genotype file.


### PR DESCRIPTION
When filtering a VCF file to only specific RSIDs, it is useful to ensure the RSIDs are in a `set` object as the performance boost from O(1) vs O(n) can make a big difference to performance, especially when using larger number of RSIDs. By using a `frozenset` it also ensures that this collection can't be accidentally modified elsewhere.