### PR TITLE
allow sex dedup determination

### DIFF
--- a/src/snps/snps.py
+++ b/src/snps/snps.py
@@ -99,6 +99,12 @@ class SNPs:
             processes to launch if multiprocessing
         rsids : tuple, optional
             rsids to extract if loading a VCF file
+        sex_method : string
+            sex detection method code: "X", "Y", "XY" and "YX supported
+        sex_heterozygous_x_threshold : float
+            proportion of X snps that should be heterozygous to detect female
+        sex_notnull_y_threshold : float
+            proportion of Y snps that should be not null to detect male
         """
         self._file = file
         self._only_detect_source = only_detect_source

--- a/src/snps/snps.py
+++ b/src/snps/snps.py
@@ -84,9 +84,10 @@ class SNPs:
             name / path of resources directory
         deduplicate : bool
             deduplicate RSIDs and make SNPs available as `SNPs.duplicate`
-        deduplicate_XY_chrom : bool
+        deduplicate_XY_chrom : bool or str
             deduplicate alleles in the non-PAR regions of X and Y for males; see
             `SNPs.discrepant_XY`
+            if a `str` then this is the sex determination method: "X", "Y" or "XY"            
         deduplicate_MT_chrom : bool
             deduplicate alleles on MT; see `SNPs.heterozygous_MT`
         parallelize : bool
@@ -156,7 +157,9 @@ class SNPs:
                     self.sort()
 
                 if deduplicate_XY_chrom:
-                    if self.determine_sex() == "Male":
+                    if (
+                        deduplicate_XY_chrom is True and self.determine_sex() == "Male"
+                    ) or self.determine_sex(chrom=deduplicate_XY_chrom) == "Male":
                         self._deduplicate_XY_chrom()
 
                 if deduplicate_MT_chrom:

--- a/src/snps/snps.py
+++ b/src/snps/snps.py
@@ -70,7 +70,6 @@ class SNPs:
         sex_method="X",
         sex_heterozygous_x_threshold=0.03,
         sex_notnull_y_threshold=0.3,
-        
     ):
         """ Object used to read, write, and remap genotype / raw data files.
 
@@ -812,9 +811,7 @@ class SNPs:
         """
         return len(self._filter(chrom))
 
-    def determine_sex(
-        self
-    ):
+    def determine_sex(self):
         """ Determine sex from SNPs.
 
         Returns
@@ -833,34 +830,56 @@ class SNPs:
             if not self.get_count("X"):
                 # no X so can't determine
                 return ""
-            elif len(self.heterozygous("X")) / self.get_count("X") > self._sex_heterozygous_x_threshold:
+            elif (
+                len(self.heterozygous("X")) / self.get_count("X")
+                > self._sex_heterozygous_x_threshold
+            ):
                 return "Female"
             else:
                 return "Male"
         elif self._sex_method == "Y":
-            # null Y snps indicates it couldn't be determined 
+            # null Y snps indicates it couldn't be determined
             # and therefore chromomse is missing
             # Y is very identifiable, so is missing in some providers
             if not self.get_count("Y"):
                 # no Y so can't determine
                 return ""
-            elif len(self.notnull("Y")) / self.get_count("Y") > self._sex_notnull_y_threshold:
+            elif (
+                len(self.notnull("Y")) / self.get_count("Y")
+                > self._sex_notnull_y_threshold
+            ):
                 return "Male"
             else:
                 return "Female"
         elif self._sex_method == "XY":
             # check for heterozygous X, then non-null Y
             # safer than just checking one in some cases, will leave sex unassinged if insufficient information
-            if self.get_count("X") and len(self.heterozygous("X")) / self.get_count("X") > self._sex_heterozygous_x_threshold:
+            if (
+                self.get_count("X")
+                and len(self.heterozygous("X")) / self.get_count("X")
+                > self._sex_heterozygous_x_threshold
+            ):
                 return "Female"
-            elif self.get_count("Y") and len(self.notnull("Y")) / self.get_count("Y") > self._sex_notnull_y_threshold:
+            elif (
+                self.get_count("Y")
+                and len(self.notnull("Y")) / self.get_count("Y")
+                > self._sex_notnull_y_threshold
+            ):
                 return "Male"
         elif self._sex_method == "YX":
             # check for non-null Y, then heterozygous X
             # safer than just checking one in some cases, will leave sex unassinged if insufficient information
-            if self.get_count("Y") and len(self.notnull("Y")) / self.get_count("Y") > self._sex_notnull_y_threshold:
+            if (
+                self.get_count("Y")
+                and len(self.notnull("Y")) / self.get_count("Y")
+                > self._sex_notnull_y_threshold
+            ):
                 return "Male"
-            elif self.get_count("X") and len(self.heterozygous("X")) / self.get_count("X") > self._sex_heterozygous_x_threshold:
+            elif (
+                self.get_count("X")
+                and len(self.heterozygous("X")) / self.get_count("X")
+                > self._sex_heterozygous_x_threshold
+            ):
                 return "Female"
         else:
             raise ValueError(f"Unrecognized sex detection method {self._sex_method}")

--- a/src/snps/snps.py
+++ b/src/snps/snps.py
@@ -833,7 +833,7 @@ class SNPs:
             if not self.get_count("X"):
                 # no X so can't determine
                 return ""
-            if len(self.heterozygous("X")) / self.get_count("X") > self._sex_heterozygous_x_threshold:
+            elif len(self.heterozygous("X")) / self.get_count("X") > self._sex_heterozygous_x_threshold:
                 return "Female"
             else:
                 return "Male"
@@ -844,7 +844,7 @@ class SNPs:
             if not self.get_count("Y"):
                 # no Y so can't determine
                 return ""
-            if len(self.notnull("Y")) / self.get_count("Y") > self._sex_notnull_y_threshold:
+            elif len(self.notnull("Y")) / self.get_count("Y") > self._sex_notnull_y_threshold:
                 return "Male"
             else:
                 return "Female"
@@ -853,14 +853,14 @@ class SNPs:
             # safer than just checking one in some cases, will leave sex unassinged if insufficient information
             if self.get_count("X") and len(self.heterozygous("X")) / self.get_count("X") > self._sex_heterozygous_x_threshold:
                 return "Female"
-            if self.get_count("Y") and len(self.notnull("Y")) / self.get_count("Y") > self._sex_notnull_y_threshold:
+            elif self.get_count("Y") and len(self.notnull("Y")) / self.get_count("Y") > self._sex_notnull_y_threshold:
                 return "Male"
         elif self._sex_method == "YX":
             # check for non-null Y, then heterozygous X
             # safer than just checking one in some cases, will leave sex unassinged if insufficient information
             if self.get_count("Y") and len(self.notnull("Y")) / self.get_count("Y") > self._sex_notnull_y_threshold:
                 return "Male"
-            if self.get_count("X") and len(self.heterozygous("X")) / self.get_count("X") > self._sex_heterozygous_x_threshold:
+            elif self.get_count("X") and len(self.heterozygous("X")) / self.get_count("X") > self._sex_heterozygous_x_threshold:
                 return "Female"
         else:
             raise ValueError(f"Unrecognized sex detection method {self._sex_method}")

--- a/tests/test_snps.py
+++ b/tests/test_snps.py
@@ -369,27 +369,27 @@ class TestSnps(BaseSNPsTestCase):
         s = self.simulate_snps(
             chrom="X", pos_start=1, pos_max=155270560, pos_step=10000, genotype="AC"
         )
-        s._sex_method="X"
+        s._sex_method = "X"
         self.assertEqual(s.sex, "Female")
-        s._sex_method="Y"
-        self.assertEqual(s.sex, "") # can't detect sex, no Y present
-        s._sex_method="XY"
+        s._sex_method = "Y"
+        self.assertEqual(s.sex, "")  # can't detect sex, no Y present
+        s._sex_method = "XY"
         self.assertEqual(s.sex, "Female")
-        s._sex_method="YX"
+        s._sex_method = "YX"
         self.assertEqual(s.sex, "Female")
 
     def test_sex_female_Y_chrom(self):
         s = self.simulate_snps(
             chrom="Y", pos_start=1, pos_max=59373566, pos_step=10000, null_snp_step=1
         )
-        s._sex_method="X"
-        self.assertEqual(s.sex, "") # can't detect sex, no X present
-        s._sex_method="Y"
+        s._sex_method = "X"
+        self.assertEqual(s.sex, "")  # can't detect sex, no X present
+        s._sex_method = "Y"
         self.assertEqual(s.sex, "Female")
-        s._sex_method="XY"
-        self.assertEqual(s.sex, "") # can't detect sex, no X present & Y is not male
-        s._sex_method="YX"
-        self.assertEqual(s.sex, "") # can't detect sex, no X present & Y is not male
+        s._sex_method = "XY"
+        self.assertEqual(s.sex, "")  # can't detect sex, no X present & Y is not male
+        s._sex_method = "YX"
+        self.assertEqual(s.sex, "")  # can't detect sex, no X present & Y is not male
 
     def test_sex_male_X_chrom(self):
         s = self.simulate_snps(
@@ -402,14 +402,14 @@ class TestSnps(BaseSNPsTestCase):
         self.assertEqual(len(s.discrepant_XY), 0)
 
         # check that the different sex detection methods work as expected
-        s._sex_method="X"
+        s._sex_method = "X"
         self.assertEqual(s.sex, "Male")
-        s._sex_method="Y"
-        self.assertEqual(s.sex, "") # no Y chromosome
-        s._sex_method="XY"
-        self.assertEqual(s.sex, "") # can't detect sex, no Y present & X is not male
-        s._sex_method="YX"
-        self.assertEqual(s.sex, "") # can't detect sex, no Y present & X is not male
+        s._sex_method = "Y"
+        self.assertEqual(s.sex, "")  # no Y chromosome
+        s._sex_method = "XY"
+        self.assertEqual(s.sex, "")  # can't detect sex, no Y present & X is not male
+        s._sex_method = "YX"
+        self.assertEqual(s.sex, "")  # can't detect sex, no Y present & X is not male
 
     def test_sex_male_X_chrom_discrepant_XY(self):
         s = self.simulate_snps(
@@ -426,49 +426,49 @@ class TestSnps(BaseSNPsTestCase):
         pd.testing.assert_frame_equal(s.discrepant_XY, result, check_exact=True)
 
         # check that the different sex detection methods work as expected
-        s._sex_method="X"
+        s._sex_method = "X"
         self.assertEqual(s.sex, "Male")
-        s._sex_method="Y"
-        self.assertEqual(s.sex, "") # no Y chromosome
-        s._sex_method="XY"
-        self.assertEqual(s.sex, "") # can't detect sex, no Y present & X is not male
-        s._sex_method="YX"
-        self.assertEqual(s.sex, "") # can't detect sex, no Y present & X is not male
+        s._sex_method = "Y"
+        self.assertEqual(s.sex, "")  # no Y chromosome
+        s._sex_method = "XY"
+        self.assertEqual(s.sex, "")  # can't detect sex, no Y present & X is not male
+        s._sex_method = "YX"
+        self.assertEqual(s.sex, "")  # can't detect sex, no Y present & X is not male
 
     def test_sex_male_Y_chrom(self):
         s = self.simulate_snps(chrom="Y", pos_start=1, pos_max=59373566, pos_step=10000)
-        s._sex_method="X"
-        self.assertEqual(s.sex, "") # no X chromosome
-        s._sex_method="Y"
+        s._sex_method = "X"
+        self.assertEqual(s.sex, "")  # no X chromosome
+        s._sex_method = "Y"
         self.assertEqual(s.sex, "Male")
-        s._sex_method="XY"
+        s._sex_method = "XY"
         self.assertEqual(s.sex, "Male")
-        s._sex_method="YX"
+        s._sex_method = "YX"
         self.assertEqual(s.sex, "Male")
 
     def test_sex_not_determined(self):
         s = self.simulate_snps(
             chrom="1", pos_start=1, pos_max=249250621, pos_step=10000
         )
-        s._sex_method="X"
-        self.assertEqual(s.sex, "") # no X or Y chromosome
-        s._sex_method="Y"
-        self.assertEqual(s.sex, "") # no X or Y chromosome
-        s._sex_method="XY"
-        self.assertEqual(s.sex, "") # no X or Y chromosome
-        s._sex_method="YX"
-        self.assertEqual(s.sex, "") # no X or Y chromosome
+        s._sex_method = "X"
+        self.assertEqual(s.sex, "")  # no X or Y chromosome
+        s._sex_method = "Y"
+        self.assertEqual(s.sex, "")  # no X or Y chromosome
+        s._sex_method = "XY"
+        self.assertEqual(s.sex, "")  # no X or Y chromosome
+        s._sex_method = "YX"
+        self.assertEqual(s.sex, "")  # no X or Y chromosome
 
     def test_sex_no_snps(self):
         for s in self.empty_snps():
-            s._sex_method="X"
-            self.assertEqual(s.sex, "") # no X or Y chromosome
-            s._sex_method="Y"
-            self.assertEqual(s.sex, "") # no X or Y chromosome
-            s._sex_method="XY"
-            self.assertEqual(s.sex, "") # no X or Y chromosome
-            s._sex_method="YX"
-            self.assertEqual(s.sex, "") # no X or Y chromosome
+            s._sex_method = "X"
+            self.assertEqual(s.sex, "")  # no X or Y chromosome
+            s._sex_method = "Y"
+            self.assertEqual(s.sex, "")  # no X or Y chromosome
+            s._sex_method = "XY"
+            self.assertEqual(s.sex, "")  # no X or Y chromosome
+            s._sex_method = "YX"
+            self.assertEqual(s.sex, "")  # no X or Y chromosome
 
     def test_source(self):
         s = SNPs("tests/input/generic.csv")


### PR DESCRIPTION
When deduplicating sex chromosomes is a useful thing to do. However, in some conditions the default methods of sex detection can give incorrect results e.g. when homozygous reference alleles are omitted from the source such as in whole-exome or whole-genome. Therefore it is useful to be able to specify the sex detection method used when deciding how to deduplicate the sex chromosomes.

This PR both supports the existing use of a boolean for `deduplicate_XY_chrom` as well as using a String that can be passed to `determine_sex()` as the `chrom` parameter.

( I'll probably have another PR soon for improvements to `determine_sex()` itself. )