### PR TITLE
remove unnecessary __call__ functions for clarity

### DIFF
--- a/src/snps/io/reader.py
+++ b/src/snps/io/reader.py
@@ -103,7 +103,7 @@ class Reader:
         self._resources = resources
         self._rsids = frozenset(rsids)
 
-    def __call__(self):
+    def read(self):
         """ Read and parse a raw data / genotype file.
 
         Returns
@@ -222,7 +222,7 @@ class Reader:
                 flag indicating if SNPs are phased
         """
         r = cls(file, only_detect_source, resources, rsids)
-        return r()
+        return r.read()
 
     def _extract_comments(self, f, decode=False, include_data=False):
         line = self._read_line(f, decode)

--- a/src/snps/io/writer.py
+++ b/src/snps/io/writer.py
@@ -72,7 +72,7 @@ class Writer:
         self._atomic = atomic
         self._kwargs = kwargs
 
-    def __call__(self):
+    def write(self):
         if self._vcf:
             return self._write_vcf()
         else:
@@ -103,7 +103,7 @@ class Writer:
             SNPs with discrepant positions discovered while saving VCF
         """
         w = cls(snps=snps, filename=filename, vcf=vcf, atomic=atomic, **kwargs)
-        return w()
+        return w.write()
 
     def _write_csv(self):
         """ Write SNPs to a CSV file.


### PR DESCRIPTION
The `Reader` and `Writer` classes currently uses the python special `__call__` method names so instances can be executed as functions. However, these are only called as functions internally from class methods, and therefore the same functionality can be done by a more straightforward public method. This makes it easier to understand the code and maintain.