### PR TITLE
remove singleton metaclass

### DIFF
--- a/src/snps/resources.py
+++ b/src/snps/resources.py
@@ -63,12 +63,12 @@ from atomicwrites import atomic_write
 import numpy as np
 
 from snps.ensembl import EnsemblRestClient
-from snps.utils import create_dir, Singleton
+from snps.utils import create_dir
 
 logger = logging.getLogger(__name__)
 
 
-class Resources(metaclass=Singleton):
+class Resources:
     """ Object used to manage resources required by `snps`. """
 
     def __init__(self, resources_dir="resources"):

--- a/src/snps/snps.py
+++ b/src/snps/snps.py
@@ -60,7 +60,8 @@ class SNPs:
         only_detect_source=False,
         assign_par_snps=False,
         output_dir="output",
-        resources_dir="resources",
+        resources_dir=None,
+        resources_obj=Resources(resources_dir="resources"),
         deduplicate=True,
         deduplicate_XY_chrom=True,
         deduplicate_MT_chrom=True,
@@ -81,7 +82,9 @@ class SNPs:
         output_dir : str
             path to output directory
         resources_dir : str
-            name / path of resources directory
+            name / path of resources directory if resources_obj is None
+        resources_obj : None or Resources
+            resources object to use
         deduplicate : bool
             deduplicate RSIDs and make SNPs available as `SNPs.duplicate`
         deduplicate_XY_chrom : bool
@@ -110,7 +113,12 @@ class SNPs:
         self._build = 0
         self._build_detected = False
         self._output_dir = output_dir
-        self._resources = Resources(resources_dir=resources_dir)
+        if resources_dir:
+            self._resources = Resources(resources_dir=resources_dir)
+        elif resources_obj:
+            self._resources = resources_obj
+        else:
+            raise ValueError("One of resources_dir or resources_obj must be defined")
         self._parallelizer = Parallelizer(parallelize=parallelize, processes=processes)
 
         if file:

--- a/src/snps/utils.py
+++ b/src/snps/utils.py
@@ -89,16 +89,6 @@ class Parallelizer:
             return map(f, tasks)
 
 
-class Singleton(type):
-    # https://stackoverflow.com/a/6798042
-    _instances = {}
-
-    def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
-        return cls._instances[cls]
-
-
 def create_dir(path):
     """ Create directory specified by `path` if it doesn't already exist.
 

--- a/tests/io/test_writer.py
+++ b/tests/io/test_writer.py
@@ -82,10 +82,10 @@ class TestWriter(BaseSNPsTestCase):
         self.run_parsing_tests("output/generic.csv", "generic")
 
     def test_save_snps_vcf(self):
-        s = SNPs("tests/input/testvcf.vcf")
-
         r = Resources()
         r._reference_sequences["GRCh37"] = {}
+
+        s = SNPs("tests/input/testvcf.vcf", resources_obj=r)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             dest = os.path.join(tmpdir, "generic.fa.gz")
@@ -100,10 +100,10 @@ class TestWriter(BaseSNPsTestCase):
         self.run_parsing_tests_vcf("output/vcf_GRCh37.vcf")
 
     def test_save_snps_vcf_false_positive_build(self):
-        snps = SNPs("tests/input/testvcf.vcf")
-
         r = Resources()
         r._reference_sequences["GRCh37"] = {}
+
+        snps = SNPs("tests/input/testvcf.vcf", resources_obj=r)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             dest = os.path.join(tmpdir, "generic.fa.gz")
@@ -130,10 +130,10 @@ class TestWriter(BaseSNPsTestCase):
         self.run_parsing_tests_vcf(output)
 
     def test_save_snps_vcf_discrepant_pos(self):
-        s = SNPs("tests/input/testvcf.vcf")
-
         r = Resources()
         r._reference_sequences["GRCh37"] = {}
+
+        s = SNPs("tests/input/testvcf.vcf", resources_obj=r)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             dest = os.path.join(tmpdir, "generic.fa.gz")
@@ -164,12 +164,10 @@ class TestWriter(BaseSNPsTestCase):
         self.run_parsing_tests_vcf("output/vcf_GRCh37.vcf", snps_df=expected)
 
     def test_save_snps_vcf_phased(self):
-        # read phased data
-        s = SNPs("tests/input/testvcf_phased.vcf")
-
-        # setup resource to use test FASTA reference sequence
         r = Resources()
         r._reference_sequences["GRCh37"] = {}
+
+        s = SNPs("tests/input/testvcf_phased.vcf", resources_obj=r)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             dest = os.path.join(tmpdir, "generic.fa.gz")


### PR DESCRIPTION
The use of a metaclass to make Resource a singleton is a bit counter-intuitive. Particularly as users won't often interact with this class directly, and I've been caught out by passing a value into `SNPs(resource_dir='something')` and not seeing the expected result because a Resource single had been created elsewhere.

This PR removes that singleton metaclass, and achieves the same behaviour by default by creating the instance as the default argument to the `SNPs.__init__` method. Default method arguments are evaluated when the class is defined, therefore objects created as a default argument are singleton.

Users who want to manage the singleton themselves can use the `resources_obj` argument to pass the `Resource` instance to use. This also opens the possibility for having different sub-classes e.g. for storage backends such as a database, or AWS S3.