### PR TITLE
Fix OverflowError

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -267,7 +267,7 @@ Thanks to Mike Agostino, Padma Reddy, Kevin Arvai, `openSNP <https://opensnp.org
 `Open Humans <https://www.openhumans.org>`_, and `Sano Genetics <https://sanogenetics.com>`_.
 
 ``snps`` incorporates code and concepts generated with the assistance of
-`OpenAI's <https://openai.com>`_ `ChatGPT <https://chat.openai.com>`_ (GPT-3.5). ✨
+`OpenAI's <https://openai.com>`_ `ChatGPT <https://chat.openai.com>`_. ✨
 
 License
 -------

--- a/src/snps/snps.py
+++ b/src/snps/snps.py
@@ -1418,7 +1418,11 @@ class SNPs:
             else:
                 # mapping is on same (plus) strand, so just remap based on offset
                 offset = mapped_start - orig_start
-                temp.loc[snp_indices, "pos"] = temp["pos"] + offset
+
+                # Adjust pos by offset based on sign of offset (avoids OverflowError with uint32)
+                temp.loc[snp_indices, "pos"] = (
+                    temp["pos"] - abs(offset) if offset < 0 else temp["pos"] + offset
+                )
 
             # mark these SNPs as remapped
             temp.loc[snp_indices, "remapped"] = True


### PR DESCRIPTION
Updates from [Sano Genetics](https://sanogenetics.com) to fix `OverflowError` with `uint32` data type during remapping.